### PR TITLE
Refactor: 폼 제출 완료 후 모달 닫기 & 일부 css 파일 제거

### DIFF
--- a/src/project/component/DraggableTable.css
+++ b/src/project/component/DraggableTable.css
@@ -1,7 +1,0 @@
-tr.drop-over-downward td {
-  border-bottom: 2px solid #1890ff;
-}
-
-tr.drop-over-upward td {
-  border-top: 2px solid #1890ff;
-}

--- a/src/project/component/DraggableTable.js
+++ b/src/project/component/DraggableTable.js
@@ -2,7 +2,20 @@ import { Table } from 'antd';
 import React, { useRef } from 'react';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 import { DndProvider, useDrag, useDrop } from 'react-dnd';
-import './DraggableTable.css';
+import styled from 'styled-components';
+
+const Row = styled.tr`
+  & td {
+    border-bottom: ${({ isDragOver, dragDirection }) =>
+      isDragOver && dragDirection === 'downward'
+        ? '2px solid #1890ff !important'
+        : ''};
+    border-top: ${({ isDragOver, dragDirection }) =>
+      isDragOver && dragDirection === 'upward'
+        ? '2px solid #1890ff !important'
+        : ''};
+  }
+`;
 
 /**
  * 드래그로 순서 변경이 가능한 테이블 컴포넌트
@@ -33,7 +46,7 @@ function DraggableTableRow({ index, onMove, className, style, ...restProps }) {
   const [, dragRef] = useDrag({
     item: { type: REACT_DND_ITEM_TYPE, index },
   });
-  const [{ isOver, dropClassName }, dropRef] = useDrop({
+  const [{ isDragOver, dragDirection }, dropRef] = useDrop({
     accept: REACT_DND_ITEM_TYPE,
     drop: item => {
       if (item.index === index) return;
@@ -46,9 +59,8 @@ function DraggableTableRow({ index, onMove, className, style, ...restProps }) {
       if (dragIndex === index) return {};
 
       return {
-        isOver: monitor.isOver(),
-        dropClassName:
-          dragIndex < index ? ' drop-over-downward' : ' drop-over-upward',
+        isDragOver: monitor.isOver(),
+        dragDirection: dragIndex < index ? 'downward' : 'upward',
       };
     },
   });
@@ -56,9 +68,11 @@ function DraggableTableRow({ index, onMove, className, style, ...restProps }) {
   dropRef(dragRef(ref));
 
   return (
-    <tr
+    <Row
+      isDragOver={isDragOver}
+      dragDirection={dragDirection}
       ref={ref}
-      className={`${className}${isOver ? dropClassName : ''}`}
+      className={className}
       style={{ cursor: 'move', ...style }}
       {...restProps}
     />

--- a/src/project/component/HeaderUpload.css
+++ b/src/project/component/HeaderUpload.css
@@ -1,4 +1,0 @@
-.header-uploader > .ant-upload {
-  width: 100%;
-  overflow: hidden;
-}

--- a/src/project/container/Project.js
+++ b/src/project/container/Project.js
@@ -72,10 +72,7 @@ export default function Project() {
         <Space>
           <Button
             size="small"
-            onClick={() => {
-              dispatch(actions.setValue('currentProjectId', record.id));
-              dispatch(actions.setValue('showProjectForm', true));
-            }}
+            onClick={() => dispatch(actions.openProjectForm(record.id))}
           >
             {I18N.PROJECT_LIST_ITEM_EDIT}
           </Button>
@@ -103,11 +100,6 @@ export default function Project() {
     },
   ];
 
-  function closeProjectForm() {
-    dispatch(actions.setValue('currentProjectId', null));
-    dispatch(actions.setValue('showProjectForm', false));
-  }
-
   return (
     <>
       <ContentHeader />
@@ -130,13 +122,7 @@ export default function Project() {
             type="primary"
             icon={isFetching ? <LoadingOutlined /> : <PlusOutlined />}
             disabled={isFetching}
-            onClick={() =>
-              dispatch(
-                actions.fetchCreateProject(() => {
-                  dispatch(actions.setValue('showProjectForm', true));
-                })
-              )
-            }
+            onClick={() => dispatch(actions.fetchCreateProject())}
           >
             {I18N.ADD_PROJECT}
           </Button>
@@ -158,11 +144,10 @@ export default function Project() {
             actions.fetchUpdateProject({
               values,
               fetchKey: currentProjectId,
-              callback: closeProjectForm,
             })
           )
         }
-        onCancel={closeProjectForm}
+        onCancel={() => dispatch(actions.closeProjectForm())}
       />
     </>
   );

--- a/src/project/container/Project.js
+++ b/src/project/container/Project.js
@@ -15,7 +15,6 @@ import {
 } from '../state/selector';
 import FetchLabel from '../component/FetchLabel';
 import DraggableTable from '../component/DraggableTable';
-import '../component/HeaderUpload.css';
 import ProjectForm from './ProjectForm';
 import { I18N } from '../../common/constant';
 import useFetchInfo from '../../common/hook/useFetchInfo';

--- a/src/project/container/ProjectForm.js
+++ b/src/project/container/ProjectForm.js
@@ -8,7 +8,6 @@ import React, { useEffect } from 'react';
 import styled from 'styled-components';
 import { API_HOST, I18N } from '../../common/constant';
 import SingleUpload from '../component/SingleUpload';
-import '../component/HeaderUpload.css';
 import useFetchInfo from '../../common/hook/useFetchInfo';
 import { actions } from '../state';
 

--- a/src/project/state/index.js
+++ b/src/project/state/index.js
@@ -12,6 +12,10 @@ export const actions = {
   editProject: createAction('project/editProject', project => ({
     payload: { project },
   })),
+  openProjectForm: createAction('project/openProjectForm', projectId => ({
+    payload: projectId,
+  })),
+  closeProjectForm: createAction('project/closeProjectForm'),
   fetchProjectList: createAction('project/fetchProjectList'),
   fetchRemoveProject: createAction('project/fetchRemoveProject', project => ({
     payload: project,
@@ -22,18 +26,13 @@ export const actions = {
       to,
     },
   })),
-  fetchCreateProject: createAction('project/fetchCreateProject', callback => ({
-    payload: {
-      callback,
-    },
-  })),
+  fetchCreateProject: createAction('project/fetchCreateProject'),
   fetchUpdateProject: createAction(
     'project/fetchUpdateProject',
-    ({ values, fetchKey, callback }) => ({
+    ({ values, fetchKey }) => ({
       payload: values,
       meta: {
         [FETCH_KEY]: fetchKey,
-        callback,
       },
     })
   ),
@@ -63,6 +62,14 @@ const reducer = createReducer(INITIAL_STATE, builder => {
       if (targetIndex !== -1) {
         state.projectList[targetIndex] = project;
       }
+    })
+    .addCase(actions.openProjectForm, (state, action) => {
+      state.currentProjectId = action.payload;
+      state.showProjectForm = true;
+    })
+    .addCase(actions.closeProjectForm, state => {
+      state.currentProjectId = null;
+      state.showProjectForm = false;
     });
 });
 

--- a/src/project/state/saga.js
+++ b/src/project/state/saga.js
@@ -59,21 +59,20 @@ function* fetchMoveProject({ payload }) {
   }
 }
 
-function* fetchCreateProject({ payload }) {
+function* fetchCreateProject() {
   const { isSuccess, data, errorMessage } = yield call(callApi, {
     method: 'post',
     url: '/project',
   });
 
   if (isSuccess && data) {
-    yield put(actions.setValue('currentProjectId', data.id));
-    payload.callback && payload.callback();
+    yield put(actions.openProjectForm(data.id));
   } else {
     message.error(errorMessage);
   }
 }
 
-function* fetchUpdateProject({ payload, meta }) {
+function* fetchUpdateProject({ payload }) {
   const { isSuccess, data, errorMessage } = yield call(callApi, {
     method: 'put',
     url: `/project/${payload.id}`,
@@ -88,7 +87,7 @@ function* fetchUpdateProject({ payload, meta }) {
       yield put(actions.addProject(data));
     }
 
-    meta.callback && meta.callback();
+    yield put(actions.closeProjectForm());
   } else {
     message.error(errorMessage);
   }


### PR DESCRIPTION
# 요약
v0.1의 일부 리팩토링
# PR 상세
## 1) 폼 제출 완료 후 모달 닫는 로직 변경
Action 객체에 callback을 사용하는 대신, saga 함수 내부에서 api 호출 후 action을 발생시키도록 변경
## 2) 일부 css 파일 styled-components로 대체
styled-components를 사용하여 불필요하게 남아있던 css 파일 제거(HeaderUpload.css, DraggableTable.css)